### PR TITLE
Update fixtures to clear os envs and prepare the DB

### DIFF
--- a/fed_reg/config.py
+++ b/fed_reg/config.py
@@ -94,6 +94,7 @@ class Settings(BaseSettings):
         """Sub class to set attribute as case sensitive."""
 
         case_sensitive = True
+        validate_assignment = True
 
 
 @lru_cache


### PR DESCRIPTION
Prepare the database only at session level. Use monkeypatch fixture to patch os environment. Override the neo4j DB URL with the test one everytime except when testing settings.