### PR TITLE
Fix nginx usage

### DIFF
--- a/fed_reg/config.py
+++ b/fed_reg/config.py
@@ -23,6 +23,7 @@ class Settings(BaseSettings):
     PROJECT_NAME: str = "Federation-Registry"
     DOMAIN: str = "localhost:8000"
     API_V1_STR: str = "/api/v1"
+    ROOT_PATH: str | None = None
 
     @validator("API_V1_STR")
     @classmethod
@@ -81,7 +82,11 @@ class Settings(BaseSettings):
         if v:
             return v
         protocol = "http"
-        link = os.path.join(values.get("DOMAIN"), values.get("API_V1_STR")[1:], "docs")
+        root_path = values.get("ROOT_PATH", "/")
+        root_path = root_path[1:] if root_path is not None else ""
+        link = os.path.join(
+            values.get("DOMAIN"), root_path, values.get("API_V1_STR")[1:], "docs"
+        )
         return f"{protocol}://{link}"
 
     # BACKEND_CORS_ORIGINS is a JSON-formatted list of origins

--- a/fed_reg/main.py
+++ b/fed_reg/main.py
@@ -43,6 +43,7 @@ app = FastAPI(
     summary=summary,
     title=settings.PROJECT_NAME,
     version=version,
+    root_path=settings.ROOT_PATH,
 )
 # if settings.BACKEND_CORS_ORIGINS:
 #     app.add_middleware(

--- a/poetry.lock
+++ b/poetry.lock
@@ -554,22 +554,22 @@ test = ["pytest (>=6)"]
 
 [[package]]
 name = "fastapi"
-version = "0.109.2"
+version = "0.108.0"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "fastapi-0.109.2-py3-none-any.whl", hash = "sha256:2c9bab24667293b501cad8dd388c05240c850b58ec5876ee3283c47d6e1e3a4d"},
-    {file = "fastapi-0.109.2.tar.gz", hash = "sha256:f3817eac96fe4f65a2ebb4baa000f394e55f5fccdaf7f75250804bc58f354f73"},
+    {file = "fastapi-0.108.0-py3-none-any.whl", hash = "sha256:8c7bc6d315da963ee4cdb605557827071a9a7f95aeb8fcdd3bde48cdc8764dd7"},
+    {file = "fastapi-0.108.0.tar.gz", hash = "sha256:5056e504ac6395bf68493d71fcfc5352fdbd5fda6f88c21f6420d80d81163296"},
 ]
 
 [package.dependencies]
 pydantic = ">=1.7.4,<1.8 || >1.8,<1.8.1 || >1.8.1,<2.0.0 || >2.0.0,<2.0.1 || >2.0.1,<2.1.0 || >2.1.0,<3.0.0"
-starlette = ">=0.36.3,<0.37.0"
+starlette = ">=0.29.0,<0.33.0"
 typing-extensions = ">=4.8.0"
 
 [package.extras]
-all = ["email-validator (>=2.0.0)", "httpx (>=0.23.0)", "itsdangerous (>=1.1.0)", "jinja2 (>=2.11.2)", "orjson (>=3.2.1)", "pydantic-extra-types (>=2.0.0)", "pydantic-settings (>=2.0.0)", "python-multipart (>=0.0.7)", "pyyaml (>=5.3.1)", "ujson (>=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0)", "uvicorn[standard] (>=0.12.0)"]
+all = ["email-validator (>=2.0.0)", "httpx (>=0.23.0)", "itsdangerous (>=1.1.0)", "jinja2 (>=2.11.2)", "orjson (>=3.2.1)", "pydantic-extra-types (>=2.0.0)", "pydantic-settings (>=2.0.0)", "python-multipart (>=0.0.5)", "pyyaml (>=5.3.1)", "ujson (>=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0)", "uvicorn[standard] (>=0.12.0)"]
 
 [[package]]
 name = "filelock"
@@ -1793,13 +1793,13 @@ files = [
 
 [[package]]
 name = "starlette"
-version = "0.36.3"
+version = "0.32.0.post1"
 description = "The little ASGI library that shines."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "starlette-0.36.3-py3-none-any.whl", hash = "sha256:13d429aa93a61dc40bf503e8c801db1f1bca3dc706b10ef2434a36123568f044"},
-    {file = "starlette-0.36.3.tar.gz", hash = "sha256:90a671733cfb35771d8cc605e0b679d23b992f8dcfad48cc60b38cb29aeb7080"},
+    {file = "starlette-0.32.0.post1-py3-none-any.whl", hash = "sha256:cd0cb10ddb49313f609cedfac62c8c12e56c7314b66d89bb077ba228bada1b09"},
+    {file = "starlette-0.32.0.post1.tar.gz", hash = "sha256:e54e2b7e2fb06dff9eac40133583f10dfa05913f5a85bf26f427c7a40a9a3d02"},
 ]
 
 [package.dependencies]
@@ -1807,7 +1807,7 @@ anyio = ">=3.4.0,<5"
 typing-extensions = {version = ">=3.10.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
-full = ["httpx (>=0.22.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.7)", "pyyaml"]
+full = ["httpx (>=0.22.0)", "itsdangerous", "jinja2", "python-multipart", "pyyaml"]
 
 [[package]]
 name = "tinycss2"
@@ -1974,4 +1974,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0.0"
-content-hash = "fb9ba5f3951bd35018a2b11218096b4ba1af12a042264c207148a888e0c33966"
+content-hash = "e81cf93267efcd7beed8118e390dc70f8ca7bc84767d54884f53662c82691760"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ packages = [{ include = "fed_reg"}]
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0.0"
 flaat = "^1.1.15"
-fastapi = "^0.109"
+fastapi = "^0.108"
 uvicorn = "^0.22.0"
 neomodel = "^5.3.0"
 pydantic = {extras = ["email"], version = "^1.10.9"}


### PR DESCRIPTION
FastAPI 0.109 has issues when using nginx. Revert to version 0.108 of FastAPI and update logic to use the root_path.