### PR TITLE
Fix wrong duplication of usage quotas

### DIFF
--- a/tests/models/test_quota_model.py
+++ b/tests/models/test_quota_model.py
@@ -203,13 +203,10 @@ def test_linked_object_store_service(
     assert object_store_quota_model.service.name
     assert object_store_quota_model.service.source
     assert isinstance(object_store_quota_model.service.source, Quota)
-    assert (
-        object_store_quota_model.service.source.uid == object_store_quota_model.uid
-    )
+    assert object_store_quota_model.service.source.uid == object_store_quota_model.uid
     assert object_store_quota_model.service.definition
     assert (
-        object_store_quota_model.service.definition["node_class"]
-        == ObjectStoreService
+        object_store_quota_model.service.definition["node_class"] == ObjectStoreService
     )
 
     r = object_store_quota_model.service.connect(object_store_service_model)

--- a/tests/models/test_service_model.py
+++ b/tests/models/test_service_model.py
@@ -313,13 +313,11 @@ def test_linked_object_store_quota(
     assert object_store_service_model.quotas.source
     assert isinstance(object_store_service_model.quotas.source, ObjectStoreService)
     assert (
-        object_store_service_model.quotas.source.uid
-        == object_store_service_model.uid
+        object_store_service_model.quotas.source.uid == object_store_service_model.uid
     )
     assert object_store_service_model.quotas.definition
     assert (
-        object_store_service_model.quotas.definition["node_class"]
-        == ObjectStoreQuota
+        object_store_service_model.quotas.definition["node_class"] == ObjectStoreQuota
     )
 
     r = object_store_service_model.quotas.connect(object_store_quota_model)

--- a/tests/schemas/test_block_storage_quota_invalid_schema_cases.py
+++ b/tests/schemas/test_block_storage_quota_invalid_schema_cases.py
@@ -14,4 +14,3 @@ class CaseInvalidAttr:
     @parametrize(value=(i for i in QuotaType if i != QuotaType.BLOCK_STORAGE))
     def case_type(self, value: QuotaType) -> tuple[Literal["type"], QuotaType]:
         return "type", value
-

--- a/tests/schemas/test_object_storage_quota_schema.py
+++ b/tests/schemas/test_object_storage_quota_schema.py
@@ -38,9 +38,7 @@ def test_read_public(
 
 
 @parametrize_with_cases("key, value")
-def test_read(
-    object_store_quota_model: ObjectStoreQuota, key: str, value: Any
-) -> None:
+def test_read(object_store_quota_model: ObjectStoreQuota, key: str, value: Any) -> None:
     if key:
         object_store_quota_model.__setattr__(key, value)
     item = ObjectStoreQuotaRead.from_orm(object_store_quota_model)


### PR DESCRIPTION
When updating usage quotas they were copied multiple times.
This was caused by a wrong division of quota types in the update procedure of the CRUD Service classes.
This PR resolves the problem.