### PR TITLE
Add region details to projects' network item

### DIFF
--- a/fed_reg/project/api/utils.py
+++ b/fed_reg/project/api/utils.py
@@ -14,24 +14,29 @@ def filter_on_region_attr(  # noqa: C901
     if not attrs:
         return items
 
+    new_items = []
     for item in items:
         for quota in item.quotas:
             service = quota.service.single()
             if not service.region.get_or_none(**attrs):
                 item.quotas = item.quotas.exclude(uid=quota.uid)
-        for flavor in item.private_flavors:
-            service = flavor.services.single()
-            if not service.region.get_or_none(**attrs):
-                item.private_flavors = item.private_flavors.exclude(uid=flavor.uid)
-        for image in item.private_images:
-            service = image.services.single()
-            if not service.region.get_or_none(**attrs):
-                item.private_images = item.private_images.exclude(uid=image.uid)
-        for network in item.private_networks:
-            service = network.service.single()
-            if not service.region.get_or_none(**attrs):
-                item.private_networks = item.private_networks.exclude(uid=network.uid)
-    return items
+        if len(item.quotas) > 0:
+            for flavor in item.private_flavors:
+                service = flavor.services.single()
+                if not service.region.get_or_none(**attrs):
+                    item.private_flavors = item.private_flavors.exclude(uid=flavor.uid)
+            for image in item.private_images:
+                service = image.services.single()
+                if not service.region.get_or_none(**attrs):
+                    item.private_images = item.private_images.exclude(uid=image.uid)
+            for network in item.private_networks:
+                service = network.service.single()
+                if not service.region.get_or_none(**attrs):
+                    item.private_networks = item.private_networks.exclude(
+                        uid=network.uid
+                    )
+            new_items.append(item)
+    return new_items
 
 
 def filter_on_service_attr(

--- a/fed_reg/project/schemas_extended.py
+++ b/fed_reg/project/schemas_extended.py
@@ -181,6 +181,44 @@ class ObjectStoreServiceReadExtendedPublic(ObjectStoreServiceReadPublic):
     region: RegionReadPublic = Field(description=DOC_EXT_REG)
 
 
+class NetworkReadExtended(NetworkRead):
+    """Model to extend the Network data read from the DB.
+
+    Attributes:
+    ----------
+        uid (int):  unique ID.
+        description (str): Brief description.
+        name (str): Network name in the Provider.
+        uuid (str): Network unique ID in the Provider
+        is_shared (bool): Public or private Network.
+        is_router_external (bool): Network with access to outside networks. External
+            network.
+        is_default (bool): Network to use as default.
+        mtu (int | None): Metric transmission unit (B).
+        proxy_host (str | None): Proxy IP address.
+        proxy_user (str | None): Proxy username.
+        tags (list of str): list of tags associated to this Network.
+        service (NetworkServiceReadExtendedPublic): Target service. Same type of quota.
+    """
+
+    service: NetworkServiceReadExtended = Field(description=DOC_EXT_SERV)
+
+
+class NetworkReadExtendedPublic(NetworkReadPublic):
+    """Model to extend the Network public data read from the DB.
+
+    Attributes:
+    ----------
+        uid (int):  unique ID.
+        description (str): Brief description.
+        name (str): Network name in the Provider.
+        uuid (str): Network unique ID in the Provider
+        service (NetworkServiceReadExtendedPublic): Target service. Same type of quota.
+    """
+
+    service: NetworkServiceReadExtendedPublic = Field(description=DOC_EXT_SERV)
+
+
 class BlockStorageQuotaReadExtended(BlockStorageQuotaRead):
     """Model to extend the Block Storage Quota data read from the DB.
 
@@ -509,14 +547,14 @@ class ProjectReadExtended(BaseNodeRead, BaseReadPrivateExtended, ProjectBase):
         sla (SLAReadExtended | None): SLA pointing to this project.
         flavors (list of FlavorRead): Private and public accessible flavors.
         images (list of ImageRead): Private and public accessible images.
-        networks (list of NetworkRead): Private and public accessible networks.
+        networks (list of NetworkReadExtended): Private and public accessible networks.
         quotas (list of Quota): list of owned quotas pointing to the corresponding
             service (block-storage, compute and network type).
     """
 
     flavors: list[FlavorRead] = Field(description=DOC_EXT_FLAV)
     images: list[ImageRead] = Field(description=DOC_EXT_IMAG)
-    networks: list[NetworkRead] = Field(description=DOC_EXT_NETW)
+    networks: list[NetworkReadExtended] = Field(description=DOC_EXT_NETW)
     provider: ProviderReadExtended = Field(description=DOC_EXT_PROV)
     quotas: list[
         ComputeQuotaReadExtended
@@ -553,14 +591,15 @@ class ProjectReadExtendedPublic(
         sla (SLAReadExtendedPublic | None): SLA pointing to this project.
         flavors (list of FlavorReadPublic): Private and public accessible flavors.
         images (list of ImageReadPublic): Private and public accessible images.
-        networks (list of NetworkReadPublic): Private and public accessible networks.
+        networks (list of NetworkReadExtendedPublic): Private and public accessible
+            networks.
         quotas (list of QuotaPublic): list of owned quotas pointing to the corresponding
             service (block-storage, compute and network type).
     """
 
     flavors: list[FlavorReadPublic] = Field(description=DOC_EXT_FLAV)
     images: list[ImageReadPublic] = Field(description=DOC_EXT_IMAG)
-    networks: list[NetworkReadPublic] = Field(description=DOC_EXT_NETW)
+    networks: list[NetworkReadExtendedPublic] = Field(description=DOC_EXT_NETW)
     provider: ProviderReadExtendedPublic = Field(description=DOC_EXT_PROV)
     quotas: list[
         ComputeQuotaReadExtendedPublic


### PR DESCRIPTION
Fix filtering on projects endpoint when specifying a region_name.
Add service and region details to the network item of the projects endpoint